### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/haravich/custom-ssh-server/security/code-scanning/1](https://github.com/haravich/custom-ssh-server/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (applies to all jobs unless overridden), granting only what this workflow needs:

- `contents: write` (needed for commit/push to branch)
- `pull-requests: write` (needed for PR creation via `github-script`)
- `packages: write` (needed for GHCR push/login with `GITHUB_TOKEN`)

This is the single best fix here because there is one job and all privileged actions are within it; root-level permissions keep behavior unchanged while satisfying CodeQL and least-privilege documentation.

Edit only `.github/workflows/docker-image.yml`, inserting the `permissions` block between `on:` and `env:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
